### PR TITLE
Fixed MANIFEST and tidy gitignore

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1,5 +1,4 @@
 Changes
-gitignore
 html/Callbacks/CSVCustomFields/Elements/EditCustomField/EditComponentName
 html/Callbacks/CSVCustomFields/Elements/ShowCustomFields/BeforeCustomFields
 html/Callbacks/CSVCustomFields/Ticket/Create.html/BeforeCreate
@@ -25,10 +24,13 @@ inc/Module/Install/Win32.pm
 inc/Module/Install/WriteAll.pm
 inc/YAML/Tiny.pm
 lib/RT/Extension/CSVCustomFields.pm
-lib/RT/Extension/CSVCustomFields/Test.pm.in
+Makefile
 Makefile.PL
-MANIFEST			This list of files
+MANIFEST
+MANIFEST.SKIP
 META.yml
+MYMETA.json
+MYMETA.yml
 README
 static/css/csvcustomfields.css
 xt/basic.t

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -1,0 +1,22 @@
+# Don't install temp files
+\.bak$
+\.swp$
+
+# Ignore version control files
+\bRCS\b
+\bCVS\b
+\bSCCS\b
+,v$
+\B\.svn\b
+\B\.git\b
+\B\.gitignore\b
+gitignore\b
+\b_darcs\b
+
+# Ignore tmp test directory
+xt/tmp\b
+
+# Don't install test framework
+lib/RT/Extension/CSVCustomFields/Test.pm.in$
+lib/RT/Extension/CSVCustomFields/Test.pm$
+

--- a/META.yml
+++ b/META.yml
@@ -25,7 +25,7 @@ requires:
 resources:
   license: http://opensource.org/licenses/gpl-license.php
   repository: https://github.com/wheldom01/rt-extension-csvcustomfields
-version: '0.01'
+version: '0.02'
 x_module_install_rtx_version: '0.38'
 x_requires_rt: 4.4.0
 x_rt_too_new: 4.6.0

--- a/gitignore
+++ b/gitignore
@@ -14,3 +14,4 @@ pod2htm*.tmp
 /t/tmp
 /xt/tmp
 /.build
+/lib/RT/Extension/CSVCustomFields/Test.pm


### PR DESCRIPTION
Updated MANIFEST and added MANIFEST.SKIP to make sure correct files are packaged.
Prevent git from adding Test.pm which is derived from Test.pm.in